### PR TITLE
SectionedLayout and LazyImage updates

### DIFF
--- a/src/components/images/LazyImage/index.js
+++ b/src/components/images/LazyImage/index.js
@@ -48,7 +48,6 @@ class LazyImage extends Component {
 			height,
 			className,
 			imgClass,
-			alt,
 			crossOrigin,
 			lazy,
       borderRadius
@@ -67,7 +66,6 @@ class LazyImage extends Component {
         top={0}
         left={0}
         transition="opacity 0.5s linear"
-        alt={alt}
         src={(needsLoading || loaded) ? src : null}
         width={width}
         height={height}
@@ -126,10 +124,6 @@ LazyImage.propTypes = {
    */
   src: PropTypes.string,
   /**
-   * Alt text for image
-   */
-  alt: PropTypes.string,
-  /**
    * Class to apply to wrapper div if a placeholder is passed
    */
   className: PropTypes.string,
@@ -159,7 +153,6 @@ LazyImage.defaultProps = {
   placeholder: null,
   lazy: true,
   src: '',
-  alt: '',
   className: '',
   imgClass: '',
   width: '100%',

--- a/src/components/images/LazyImage/index.js
+++ b/src/components/images/LazyImage/index.js
@@ -163,7 +163,7 @@ LazyImage.defaultProps = {
   className: '',
   imgClass: '',
   width: '100%',
-  height: null,
+  height: 'auto',
   crossOrigin: null,
   borderRadius: null,
 }

--- a/src/components/layouts/SectionedLayout/index.js
+++ b/src/components/layouts/SectionedLayout/index.js
@@ -30,7 +30,7 @@ function SectionedLayout({ className, style, left, right, children }) {
       </Div>
       <Div
         position="absolute"
-        left="100%"
+        right="0"
         display="flex"
         alignItems="center"
       >


### PR DESCRIPTION
- 🐛 fix: change left 100% to right 0, so the right position isn't off by the width of the right child
- update default props for LazyImage to height: 'auto'