### PR TITLE
:bug: fix: LazyImage again..

### DIFF
--- a/src/components/images/LazyImage/index.js
+++ b/src/components/images/LazyImage/index.js
@@ -58,11 +58,10 @@ class LazyImage extends Component {
       <Img
         ref={(img) => {
           if (img) {
-            const domId = img._reactInternalInstance
-              && img._reactInternalInstance._renderedComponent
-              && img._reactInternalInstance._renderedComponent._domID
-            this._img = domId
-              && document.querySelector(`img[data-reactid="${domId}"]`)
+            // hopefully the src prop is unique...
+            const imgSrc = img.props && img.props.src
+            this._img = imgSrc
+              && document.querySelector(`img[src="${imgSrc}"]`)
           }
         }}
         onLoad={() => { this.showImgIfNeeded() }}


### PR DESCRIPTION
problem: the previous fix using the data-reactid doesn't work in versions of React greater than or equal to 15 on the client, because that attribute is only rendered on the server

solution: use a simpler method of checking the img by using the src (this assumes that we won't have multiple images with the same src)
if we do find multiple then i'll grab the first one to check if it's loaded..